### PR TITLE
Write cron logging to file

### DIFF
--- a/root/etc/cont-init.d/40-config
+++ b/root/etc/cont-init.d/40-config
@@ -6,3 +6,10 @@ chown abc:abc \
 	/data
 chown -R abc:abc  \
 	/var/lib/nginx
+
+# directories
+if [ ! -d /config/log/cron ]; then
+	mkdir -p /config/log/cron
+fi
+	
+# EOF

--- a/root/etc/services.d/cron/run
+++ b/root/etc/services.d/cron/run
@@ -1,3 +1,5 @@
 #!/usr/bin/with-contenv bash
 
-/usr/sbin/crond -f -S -l 0 -c /etc/crontabs
+/usr/sbin/crond -f -S -l 0 -c /etc/crontabs -L /config/log/cron/cron.log
+
+# EOF


### PR DESCRIPTION
Configure container to write the logging of cron to /config/log/cron/cron.log instead of docker stdout.
