### PR TITLE
add PHP Archive module needed by the occ upgrade process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN \
 	php7-pdo_pgsql \
 	php7-pdo_sqlite \
 	php7-pgsql \
+	php7-phar \
 	php7-posix \
 	php7-redis \
 	php7-sqlite3 \


### PR DESCRIPTION
This adds [php7-phar](https://pkgs.alpinelinux.org/packages?name=php7-phar&branch=edge) ([more info](https://secure.php.net/manual/en/intro.phar.php))

I ran into this requirement when trying to upgrade Nextcloud via occ commands, beginning with `updater.phar`, [as described here](https://nextcloud.com/blog/get-up-to-date-with-the-new-nextcloud-updater/). Without this dependency, that script exits silently after doing nothing. I was able to complete my upgrade after installing it.