### PR TITLE
Update the application setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ In this instance `PUID=1001` and `PGID=1001`, to find yours use `id user` as bel
 &nbsp;
 ## Application Setup
 
-Access the webui at `<your-ip>:443`, for more information check out [Nextcloud][appurl].
+Access the webui at `<your-ip>:443`, for more information check out [Nextcloud](https://nextcloud.com/).
 
 If you are updating our container along with the in app updater and you are not customizing our default nginx configuration you will need to remove the file:
 ```

--- a/README.md
+++ b/README.md
@@ -121,9 +121,11 @@ In this instance `PUID=1001` and `PGID=1001`, to find yours use `id user` as bel
 
 Access the webui at `<your-ip>:443`, for more information check out [Nextcloud][appurl].
 
-Please note you will need a MySQL/MariaDB or other backend database to set this up.  Also please look [here](https://docs.nextcloud.com/server/11/admin_manual/installation/system_requirements.html#database-requirements-for-mysql-mariadb) for how to configure your database with regard to binlog format and installation.
-
-If updating to nextcloud 12 you will need to comment out line `add_header X-Frame-Options "SAMEORIGIN";` in the file /config/nginx/site-confs/default
+If you are updating our container along with the in app updater and you are not customizing our default nginx configuration you will need to remove the file:
+```
+/config/nginx/site-confs/default
+```
+Then restart the container to replace it with the latest one. 
 
 
 
@@ -157,6 +159,7 @@ Below are the instructions for updating containers:
 
 ## Versions
 
+* **27.02.19:** - Updating base nginx config to sync up with v15 requirements.
 * **22.02.19:** - Rebasing to alpine 3.9.
 * **28.01.19:** - Add pipeline logic and multi arch.
 * **25.01.19:** - Add php7-phar for occ upgrades.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -50,12 +50,15 @@ app_setup_block_enabled: true
 app_setup_block: |
   Access the webui at `<your-ip>:443`, for more information check out [Nextcloud][appurl].
 
-  Please note you will need a MySQL/MariaDB or other backend database to set this up.  Also please look [here](https://docs.nextcloud.com/server/11/admin_manual/installation/system_requirements.html#database-requirements-for-mysql-mariadb) for how to configure your database with regard to binlog format and installation.
-
-  If updating to nextcloud 12 you will need to comment out line `add_header X-Frame-Options "SAMEORIGIN";` in the file /config/nginx/site-confs/default
+  If you are updating our container along with the in app updater and you are not customizing our default nginx configuration you will need to remove the file:
+  ```
+  /config/nginx/site-confs/default
+  ```
+  Then restart the container to replace it with the latest one. 
 
 # changelog
 changelogs:
+  - { date: "27.02.19:", desc: "Updating base nginx config to sync up with v15 requirements." }
   - { date: "22.02.19:", desc: "Rebasing to alpine 3.9." }
   - { date: "28.01.19:", desc: "Add pipeline logic and multi arch." }
   - { date: "25.01.19:", desc: "Add php7-phar for occ upgrades." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -48,7 +48,7 @@ optional_block_1: false
 # application setup block
 app_setup_block_enabled: true
 app_setup_block: |
-  Access the webui at `<your-ip>:443`, for more information check out [Nextcloud][appurl].
+  Access the webui at `<your-ip>:443`, for more information check out [Nextcloud]({{ project_url }}).
 
   If you are updating our container along with the in app updater and you are not customizing our default nginx configuration you will need to remove the file:
   ```


### PR DESCRIPTION
Pulling out legacy info, this spins up connected to a sqlite db by default and for most home users this is perfectly fine. 

Also need information about users that are using the default config to ensure they replace it if they ever update our image as a precaution. It seems like Nextcloud will continue to modify this file from major version to major version as they have done so in the past. 