### PR TITLE
Add add_header Strict-Transport-Security "max-age=15768000; includeSu…

### DIFF
--- a/root/defaults/default
+++ b/root/defaults/default
@@ -15,6 +15,7 @@ server {
     ssl_certificate_key /config/keys/cert.key;
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection "1; mode=block";
+    add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
     add_header X-Robots-Tag none;
     add_header X-Download-Options noopen;
     add_header X-Permitted-Cross-Domain-Policies none;


### PR DESCRIPTION
…bDomains; preload;"; to nginx config

without add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;"; nextcloud gave a me an error with the security check. Added this to fix this

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

