### PR TITLE
Stop gap versioning until we have a reference point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,8 +89,7 @@ RUN \
  echo "env[PATH] = /usr/local/bin:/usr/bin:/bin" >> /etc/php7/php-fpm.conf && \
  echo "**** set version tag ****" && \
  if [ -z ${NEXTCLOUD_RELEASE+x} ]; then \
- 	NEXTCLOUD_RELEASE=$(curl -s https://download.nextcloud.com/server/installer/setup-nextcloud.php \
-	| awk -F \' '/NC_VERSION/{print $4;exit}'); \
+	NEXTCLOUD_RELEASE=$(echo 15.0.7); \
  fi && \
  echo ${NEXTCLOUD_RELEASE} > /version.txt && \
  echo "**** cleanup ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -89,8 +89,7 @@ RUN \
  echo "env[PATH] = /usr/local/bin:/usr/bin:/bin" >> /etc/php7/php-fpm.conf && \
  echo "**** set version tag ****" && \
  if [ -z ${NEXTCLOUD_RELEASE+x} ]; then \
- 	NEXTCLOUD_RELEASE=$(curl -s https://download.nextcloud.com/server/installer/setup-nextcloud.php \
-	| awk -F \' '/NC_VERSION/{print $4;exit}'); \
+	NEXTCLOUD_RELEASE=$(echo 15.0.7); \
  fi && \
  echo ${NEXTCLOUD_RELEASE} > /version.txt && \
  echo "**** cleanup ****" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -89,8 +89,7 @@ RUN \
  echo "env[PATH] = /usr/local/bin:/usr/bin:/bin" >> /etc/php7/php-fpm.conf && \
  echo "**** set version tag ****" && \
  if [ -z ${NEXTCLOUD_RELEASE+x} ]; then \
- 	NEXTCLOUD_RELEASE=$(curl -s https://download.nextcloud.com/server/installer/setup-nextcloud.php \
-	| awk -F \' '/NC_VERSION/{print $4;exit}'); \
+	NEXTCLOUD_RELEASE=$(echo 15.0.7); \
  fi && \
  echo ${NEXTCLOUD_RELEASE} > /version.txt && \
  echo "**** cleanup ****" && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,8 +96,7 @@ pipeline {
       steps{
         script{
           env.EXT_RELEASE = sh(
-            script: ''' curl -s https://download.nextcloud.com/server/installer/setup-nextcloud.php | awk -F \\' '/NC_VERSION/{print $4;exit}'
- ''',
+            script: ''' echo 15.0.7 ''',
             returnStdout: true).trim()
             env.RELEASE_LINK = 'custom_command'
         }

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -3,8 +3,7 @@
 # jenkins variables
 project_name: docker-nextcloud
 external_type: na
-custom_version_command: |
-  {% raw -%}curl -s https://download.nextcloud.com/server/installer/setup-nextcloud.php | awk -F \\' '/NC_VERSION/{print $4;exit}'{%- endraw %}
+custom_version_command: 'echo 15.0.7'
 release_type: stable
 release_tag: latest
 ls_branch: master


### PR DESCRIPTION
Nextcloud updated their installer, this hard codes the version until we have a reliabled method for getting the latest stable version of Nextcloud. 

