### PR TITLE
updating endpoint to consume for versioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,7 +89,8 @@ RUN \
  echo "env[PATH] = /usr/local/bin:/usr/bin:/bin" >> /etc/php7/php-fpm.conf && \
  echo "**** set version tag ****" && \
  if [ -z ${NEXTCLOUD_RELEASE+x} ]; then \
-	NEXTCLOUD_RELEASE=$(echo 15.0.7); \
+	NEXTCLOUD_RELEASE=$(curl -s https://raw.githubusercontent.com/nextcloud/nextcloud.com/master/strings.php \
+	| awk -F\' '/VERSIONS_SERVER_FULL_STABLE/ {print $2;exit}'); \
  fi && \
  echo ${NEXTCLOUD_RELEASE} > /version.txt && \
  echo "**** cleanup ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -89,7 +89,8 @@ RUN \
  echo "env[PATH] = /usr/local/bin:/usr/bin:/bin" >> /etc/php7/php-fpm.conf && \
  echo "**** set version tag ****" && \
  if [ -z ${NEXTCLOUD_RELEASE+x} ]; then \
-	NEXTCLOUD_RELEASE=$(echo 15.0.7); \
+	NEXTCLOUD_RELEASE=$(curl -s https://raw.githubusercontent.com/nextcloud/nextcloud.com/master/strings.php \
+	| awk -F\' '/VERSIONS_SERVER_FULL_STABLE/ {print $2;exit}'); \
  fi && \
  echo ${NEXTCLOUD_RELEASE} > /version.txt && \
  echo "**** cleanup ****" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -89,7 +89,8 @@ RUN \
  echo "env[PATH] = /usr/local/bin:/usr/bin:/bin" >> /etc/php7/php-fpm.conf && \
  echo "**** set version tag ****" && \
  if [ -z ${NEXTCLOUD_RELEASE+x} ]; then \
-	NEXTCLOUD_RELEASE=$(echo 15.0.7); \
+	NEXTCLOUD_RELEASE=$(curl -s https://raw.githubusercontent.com/nextcloud/nextcloud.com/master/strings.php \
+	| awk -F\' '/VERSIONS_SERVER_FULL_STABLE/ {print $2;exit}'); \
  fi && \
  echo ${NEXTCLOUD_RELEASE} > /version.txt && \
  echo "**** cleanup ****" && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,7 +96,7 @@ pipeline {
       steps{
         script{
           env.EXT_RELEASE = sh(
-            script: ''' echo 15.0.7 ''',
+            script: ''' curl -s https://raw.githubusercontent.com/nextcloud/nextcloud.com/master/strings.php | awk -F\\' '/VERSIONS_SERVER_FULL_STABLE/ {print $2;exit}' ''',
             returnStdout: true).trim()
             env.RELEASE_LINK = 'custom_command'
         }

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -3,7 +3,7 @@
 # jenkins variables
 project_name: docker-nextcloud
 external_type: na
-custom_version_command: 'echo 15.0.7'
+custom_version_command: "curl -s https://raw.githubusercontent.com/nextcloud/nextcloud.com/master/strings.php | awk -F\\\\' '/VERSIONS_SERVER_FULL_STABLE/ {print $2;exit}'"
 release_type: stable
 release_tag: latest
 ls_branch: master


### PR DESCRIPTION
This is a fix for the stop gap echo we put in place. This endpoint is supposedly not permanent. But it should cover us for a while. 