### PR TITLE
Increase max filesize to 4GB from 2MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,8 @@ RUN \
 	-e 's/;opcache.revalidate_freq.*=.*/opcache.revalidate_freq=1/g' \
 	-e 's/;always_populate_raw_post_data.*=.*/always_populate_raw_post_data=-1/g' \
 	-e 's/memory_limit.*=.*128M/memory_limit=512M/g' \
+	-e 's/upload_max_filesize.*=.*2M/upload_max_filesize=4G/g' \
+	-e 's/post_max_size.*=.*8M/post_max_size=4G/g' \
 		/etc/php7/php.ini && \
  sed -i \
 	'/opcache.enable=1/a opcache.enable_cli=1' \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -83,7 +83,7 @@ RUN \
 	-e 's/;always_populate_raw_post_data.*=.*/always_populate_raw_post_data=-1/g' \
 	-e 's/memory_limit.*=.*128M/memory_limit=512M/g' \
 	-e 's/upload_max_filesize.*=.*2M/upload_max_filesize=4G/g' \
-    -e 's/post_max_size.*=.*8M/post_max_size=4G/g' \
+	-e 's/post_max_size.*=.*8M/post_max_size=4G/g' \
 		/etc/php7/php.ini && \
  sed -i \
 	'/opcache.enable=1/a opcache.enable_cli=1' \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -82,6 +82,8 @@ RUN \
 	-e 's/;opcache.revalidate_freq.*=.*/opcache.revalidate_freq=1/g' \
 	-e 's/;always_populate_raw_post_data.*=.*/always_populate_raw_post_data=-1/g' \
 	-e 's/memory_limit.*=.*128M/memory_limit=512M/g' \
+	-e 's/upload_max_filesize.*=.*2M/upload_max_filesize=4G/g' \
+    -e 's/post_max_size.*=.*8M/post_max_size=4G/g' \
 		/etc/php7/php.ini && \
  sed -i \
 	'/opcache.enable=1/a opcache.enable_cli=1' \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -83,7 +83,7 @@ RUN \
 	-e 's/;always_populate_raw_post_data.*=.*/always_populate_raw_post_data=-1/g' \
 	-e 's/memory_limit.*=.*128M/memory_limit=512M/g' \
 	-e 's/upload_max_filesize.*=.*2M/upload_max_filesize=4G/g' \
-    -e 's/post_max_size.*=.*8M/post_max_size=4G/g' \
+	-e 's/post_max_size.*=.*8M/post_max_size=4G/g' \
 		/etc/php7/php.ini && \
  sed -i \
 	'/opcache.enable=1/a opcache.enable_cli=1' \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -82,6 +82,8 @@ RUN \
 	-e 's/;opcache.revalidate_freq.*=.*/opcache.revalidate_freq=1/g' \
 	-e 's/;always_populate_raw_post_data.*=.*/always_populate_raw_post_data=-1/g' \
 	-e 's/memory_limit.*=.*128M/memory_limit=512M/g' \
+	-e 's/upload_max_filesize.*=.*2M/upload_max_filesize=4G/g' \
+    -e 's/post_max_size.*=.*8M/post_max_size=4G/g' \
 		/etc/php7/php.ini && \
  sed -i \
 	'/opcache.enable=1/a opcache.enable_cli=1' \


### PR DESCRIPTION
The default max filesize of PHP is 2MB with a max post size of 8MB. These values are too low to make nextcloud useful. Increase both to 4GB.