### PR TITLE
Add cron job for weekly rescan of /data

### DIFF
--- a/root/defaults/nextcloud-rescan
+++ b/root/defaults/nextcloud-rescan
@@ -1,0 +1,1 @@
+30  3  *  *  1 s6-setuidgid abc php7 -f /config/www/nextcloud/occ files:scan --all

--- a/root/etc/cont-init.d/50-install
+++ b/root/etc/cont-init.d/50-install
@@ -15,3 +15,6 @@ fi
 
 # set cronjob
 crontab /defaults/nextcloud
+
+# set rescan cronjob
+crontab /defaults/nextcloud-rescan


### PR DESCRIPTION
## Description:

Add a cron job to periodically re-scan the /data directory.

## Benefits of this PR and context:

A rescan cron job is useful in case the contents of the /data directory
are changed by an entity other than NextCloud.  For instance, the user
may copy a file into the /data directory using SCP and expect it to show
up in NextCloud.  Or a user may delete a file from NextCloud's /data
directory and expect that file to eventually disappear.

## How Has This Been Tested?

I tested running this script manually.  My NextCloud instance has 22007
folders and 234262 files.  On my machine the rescan took 1h 16m 10s.