### PR TITLE
Update 40-config to convert the db

### DIFF
--- a/root/etc/cont-init.d/40-config
+++ b/root/etc/cont-init.d/40-config
@@ -6,3 +6,6 @@ chown abc:abc \
 	/data
 chown -R abc:abc  \
 	/var/lib/nginx
+
+sudo -u abc php7 /config/www/nextcloud/occ db:add-missing-indices
+sudo -u abc php7 /config/www/nextcloud/occ db:convert-filecache-bigint


### PR DESCRIPTION
#### convert the database during the deployment which means less issues for everyone. /o/

sudo -u abc php7 /config/www/nextcloud/occ db:add-missing-indices
sudo -u abc php7 /config/www/nextcloud/occ db:convert-filecache-bigint