### PR TITLE
occ & updater.phar

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -50,7 +50,15 @@ app_setup_block_enabled: true
 app_setup_block: |
   Access the webui at `https://<your-ip>:443`, for more information check out [Nextcloud]({{ project_url }}).
 
-  In order to update nextcloud version, first make sure you are using the latest docker image, and then perform the in app gui update. Docker image update and recreation of container alone won't update nextcloud version. 
+  Docker image update and recreation of container alone won't update nextcloud version. 
+
+  In order to update nextcloud version, you have two options, firstly make sure you are using the latest docker image,then either 
+  
+  1.  Perform the in app gui update. 
+  2.  Use the CLI version by running `docker exec -it nextcloud updater.phar`
+   (Both of these are described [here](https://docs.nextcloud.com/server/latest/admin_manual/maintenance/update.html))
+
+  Note:  Both `occ` and `updater.phar` can be run without prepending with `sudo -u abc php` or `sudo -u www-data php`
   
   If you are not customizing our default nginx configuration you will need to remove the file:
   ```
@@ -58,8 +66,11 @@ app_setup_block: |
   ```
   Then restart the container to replace it with the latest one. 
 
+  
+
 # changelog
 changelogs:
+  - { date: "31.05.20:", desc: "Add aliases for occ and updater.phar" }
   - { date: "31.03.20:", desc: "Allow crontab to be user customized, fix logrotate." }
   - { date: "17.01.20:", desc: "Updated php.ini defaults and site config, including an optional HSTS directive (existing users should delete `/config/nginx/site-confs/default` and restart the container)." }
   - { date: "19.12.19:", desc: "Rebasing to alpine 3.11." }

--- a/root/etc/cont-init.d/70-aliases
+++ b/root/etc/cont-init.d/70-aliases
@@ -1,0 +1,15 @@
+#!/usr/bin/with-contenv bash
+
+## Set alias for occ and make executable
+[[ ! -f /usr/bin/occ ]] && \
+  echo -e '#!/bin/bash\nsudo -u abc php7 /config/www/nextcloud/occ' > /usr/bin/occ
+
+[[ ! -x /usr/bin/occ ]] && \
+  chmod +x /usr/bin/occ
+
+## Set alias for updater.phar and make executable
+[[ ! -f /usr/bin/updater.phar ]] && \
+  echo -e '#!/bin/bash\nsudo -u abc php7 /config/www/nextcloud/updater/updater.phar' > /usr/bin/updater.phar
+
+[[ ! -x /usr/bin/updater.phar ]] && \
+  chmod +x /usr/bin/updater.phar


### PR DESCRIPTION
Create aliases in `/usr/bin` to enable easier use of both common commands

Enables the use of `occ` and `updater.phar` easier without having to specify the full path and prepend with `sudo -u abc`

So examples: 

**To Invoke `occ` or `updater.phar` before**
`sudo -u abc php7 /config/www/nextcloud/occ` or
`docker exec -it nextcloud sudo -u abc php7 /config/www/nextcloud/occ`

`sudo -u abc php7 /config/www/nextcloud/updater/updater.phar`
`docker exec -it nextcloud sudo -u abc php7 /config/www/nextcloud/updater/updater.phar`

**To Invoke `occ` or updater.phar after**
`occ`
`docker exec -it nextcloud occ`

`updater.phar`
`docker exec -it nextcloud updater.phar`

Used this method as it was the only way I could find that worked in both an interactive and non-interactive session.

Use of the occ command in particular causes some end-user confusion on a number of levels.

Firstly it needs to be run as the `abc` user hence the `sudo -u abc`
Secondly we hit issues when php was changed from php to php7, although I think iirc that `php` works now and `php7` as a command is not necessary.
Thirdly the path we use is different to that in the Nextcloud admin docs.

I think by simplifying it all it will make things easier.