### PR TITLE
Add php7-bcmath & php7-fileinfo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,13 @@ RUN \
 	imagemagick \
 	libxml2 \
 	php7-apcu \
+	php7-bcmath \
 	php7-bz2 \
 	php7-ctype \
 	php7-curl \
 	php7-dom \
 	php7-exif \
+	php7-fileinfo \
 	php7-ftp \
 	php7-gd \
 	php7-gmp \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -30,11 +30,13 @@ RUN \
 	imagemagick \
 	libxml2 \
 	php7-apcu \
+	php7-bcmath \
 	php7-bz2 \
 	php7-ctype \
 	php7-curl \
 	php7-dom \
 	php7-exif \
+	php7-fileinfo \
 	php7-ftp \
 	php7-gd \
 	php7-gmp \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -30,11 +30,13 @@ RUN \
 	imagemagick \
 	libxml2 \
 	php7-apcu \
+	php7-bcmath \
 	php7-bz2 \
 	php7-ctype \
 	php7-curl \
 	php7-dom \
 	php7-exif \
+	php7-fileinfo \
 	php7-ftp \
 	php7-gd \
 	php7-gmp \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -70,6 +70,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "03.06.20:", desc: "Add php7-bcmath and php7-fileinfo" }
   - { date: "31.05.20:", desc: "Add aliases for occ and updater.phar" }
   - { date: "31.03.20:", desc: "Allow crontab to be user customized, fix logrotate." }
   - { date: "17.01.20:", desc: "Updated php.ini defaults and site config, including an optional HSTS directive (existing users should delete `/config/nginx/site-confs/default` and restart the container)." }


### PR DESCRIPTION
Required for NC19

See here https://docs.nextcloud.com/server/latest/admin_manual/installation/source_installation.html.

I've deferred upgrading to Alpine 3.12 as will get this fixed then test Alpine upgrade

Closes https://github.com/linuxserver/docker-nextcloud/pull/140