### PR TITLE
Fix occ alias

### DIFF
--- a/root/etc/cont-init.d/70-aliases
+++ b/root/etc/cont-init.d/70-aliases
@@ -2,7 +2,7 @@
 
 ## Set alias for occ and make executable
 [[ ! -f /usr/bin/occ ]] && \
-  echo -e '#!/bin/bash\nsudo -u abc -s /bin/bash -c "php7 /config/www/nextcloud/occ $@"' > /usr/bin/occ
+  echo -e '#!/bin/bash\nsudo -u abc -s /bin/bash -c "php7 /config/www/nextcloud/occ $*"' > /usr/bin/occ
 
 [[ ! -x /usr/bin/occ ]] && \
   chmod +x /usr/bin/occ

--- a/root/etc/cont-init.d/70-aliases
+++ b/root/etc/cont-init.d/70-aliases
@@ -2,7 +2,7 @@
 
 ## Set alias for occ and make executable
 [[ ! -f /usr/bin/occ ]] && \
-  echo -e '#!/bin/bash\nsudo -u abc php7 /config/www/nextcloud/occ' > /usr/bin/occ
+  echo -e '#!/bin/bash\nsudo -u abc -s /bin/bash -c "php7 /config/www/nextcloud/occ $@"' > /usr/bin/occ
 
 [[ ! -x /usr/bin/occ ]] && \
   chmod +x /usr/bin/occ


### PR DESCRIPTION
`occ` alias wouldn't call occ correctly, but not interpret commands