### PR TITLE
Nginx: Add rewrite rule for WebFinger

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **12.08.20:** - Various updates to default site config, including added support for webfinger (existing users should delete `/config/nginx/site-confs/default` and restart the container).
 * **03.06.20:** - Rebasing to alpine 3.12
 * **03.06.20:** - Add php7-bcmath and php7-fileinfo
 * **31.05.20:** - Add aliases for occ and updater.phar

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -70,6 +70,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "12.08.20:", desc: "Various updates to default site config, including added support for webfinger (existing users should delete `/config/nginx/site-confs/default` and restart the container)." }
   - { date: "03.06.20:", desc: "Rebasing to alpine 3.12" }
   - { date: "03.06.20:", desc: "Add php7-bcmath and php7-fileinfo" }
   - { date: "31.05.20:", desc: "Add aliases for occ and updater.phar" }

--- a/root/defaults/default
+++ b/root/defaults/default
@@ -51,6 +51,12 @@ server {
     location = /.well-known/webfinger {
       return 301 $scheme://$host:$server_port/public.php?service=webfinger;
     }
+    location = /.well-known/host-meta {
+      return 301 $scheme://$host:$server_port/public.php?service=host-meta;
+    }
+    location = /.well-known/host-meta.json {
+      return 301 $scheme://$host:$server_port/public.php?service=host-meta-json;
+    }
     client_max_body_size 10G;
     fastcgi_buffers 64 4K;
     gzip on;
@@ -68,7 +74,7 @@ server {
     location ~ ^\/(?:\.|autotest|occ|issue|indie|db_|console) {
         deny all;
     }
-    location ~ ^\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+)\.php(?:$|\/) {
+    location ~ ^\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy)\.php(?:$|\/) {
         fastcgi_split_path_info ^(.+?\.php)(\/.*|)$;
         set $path_info $fastcgi_path_info;
         try_files $fastcgi_script_name =404;
@@ -108,7 +114,7 @@ server {
         add_header Referrer-Policy no-referrer;
         access_log off;
     }
-    location ~ \.(?:png|html|ttf|ico|jpg|jpeg|bcmap)$ {
+    location ~ \.(?:png|html|ttf|ico|jpg|jpeg|bcmap|mp4|webm)$ {
         try_files $uri /index.php$request_uri;
         access_log off;
     }

--- a/root/defaults/default
+++ b/root/defaults/default
@@ -48,6 +48,9 @@ server {
     location = /.well-known/caldav {
       return 301 $scheme://$host:$server_port/remote.php/dav;
     }
+    location = /.well-known/webfinger {
+      return 301 $scheme://$host:$server_port/public.php?service=webfinger;
+    }
     client_max_body_size 10G;
     fastcgi_buffers 64 4K;
     gzip on;


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
Add rewrite rule for WebFinger as stated on the Nextcloud documentation.

## How Has This Been Tested?
I have tested it on a new container and it fixed it.


## Source / References:
https://docs.nextcloud.com/server/18/admin_manual/issues/general_troubleshooting.html#service-discovery
