### PR TITLE
Add a rewrite rule to repair the LDAP/AD app

### DIFF
--- a/root/defaults/default
+++ b/root/defaults/default
@@ -104,6 +104,9 @@ server {
     # then Nginx will encounter an infinite rewriting loop when it prepends `/index.php`
     # to the URI, resulting in a HTTP 500 error response.
     location ~ \.php(?:$|/) {
+		# Required for legacy support
+		rewrite ^/(?!index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy) /index.php$request_uri;
+        
         fastcgi_split_path_info ^(.+?\.php)(/.*)$;
         set $path_info $fastcgi_path_info;
 


### PR DESCRIPTION
This line will repair an issue wherein the LDAP app within NextCloud will not function with this container.

I added this line within my own container for testing purposes, and it resolved the LDAP app issue.
 Closes issue #195