### PR TITLE
Fix incorrect parameter expansion

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -78,6 +78,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "24.03.21:", desc: "Fix incorrect parameter expansion" }
   - { date: "11.09.21:", desc: "Rebasing to alpine 3.14" }
   - { date: "21.03.21:", desc: "Publish `php8` tag for testing." }
   - { date: "25.02.21:", desc: "Nginx default site config updated for v21 (existing users should delete `/config/nginx/site-confs/default` and restart the container)." }

--- a/root/etc/cont-init.d/70-aliases
+++ b/root/etc/cont-init.d/70-aliases
@@ -2,19 +2,19 @@
 
 ## Set alias for occ and make executable
 [[ ! -f /usr/bin/occ ]] && \
-  echo -e '#!/bin/bash\nsudo -u abc -s /bin/bash -c "php7 /config/www/nextcloud/occ $*"' > /usr/bin/occ
+  echo -e '#!/bin/bash\nsudo -u abc -s /bin/bash -c '\''php7 /config/www/nextcloud/occ "$@"'\'' - "$@"' > /usr/bin/occ
 
 [[ ! -x /usr/bin/occ ]] && \
   chmod +x /usr/bin/occ
 
 ## Set alias for updater.phar and make executable
 [[ ! -f /usr/bin/updater.phar ]] && \
-  echo -e '#!/bin/bash\nsudo -u abc -s /bin/bash -c "php7 /config/www/nextcloud/updater/updater.phar $*"' > /usr/bin/updater.phar
+  echo -e '#!/bin/bash\nsudo -u abc -s /bin/bash -c '\''php7 /config/www/nextcloud/updater/updater.phar "$@"'\'' - "$@"' > /usr/bin/updater.phar
 
 [[ ! -x /usr/bin/updater.phar ]] && \
   chmod +x /usr/bin/updater.phar
 
 if ( occ app:list --no-interaction | grep -q richdocumentscode) 2>/dev/null; then
-  echo "Removing CODE Server" 
-  occ app:remove --no-interaction richdocumentscode 2>/dev/null 
+  echo "Removing CODE Server"
+  occ app:remove --no-interaction richdocumentscode 2>/dev/null
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-nextcloud/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Fixing incorrect parameter expansion in aliases leading to parameters with spaces or other special shell characters to be incorrectly interpreted by the target command.

The PR was mainly intended to fix the `occ` alias which I personally needed to fix, but since the `updater.phar` alias used the same construct for passing parameters I also fixed it there. As far as I can see this change was not strictly required, as there is no argument allowing arbitrary values, but for the same reason it should also be backwards compatible as the problematic expansion could not have been relied upon for any parameter.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This change makes the `occ` alias behave the same way as executing the target command directly, and in particular allows to pass arguments that contain spaces.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I built a custom image based on `linuxserver/nextcloud:23.0.2` with the patched `70-aliases`, then started a container with volumes from another instance I had lying around (so that nextcloud would have been already installed) and executed a few commands that would previously give errors or unexpected results:

* Spaces were definitely causing issues, now they don't:
  ```
    # occ theming:config slogan "dis gonna gud."
  Updated slogan to dis gonna gud.
  # occ theming:config slogan 
  slogan is currently set to dis gonna gud.
  # occ config:app:get theming slogan
  dis gonna gud.
  
  # occ config:system:set test key1 key2 --value="10 20 30"
  System config value test => key1 => key2 set to string 10 20 30
  # occ config:system:get test
  key1:
    key2: 10 20 30
  # occ config:list system | grep -B 1 -A 4 test
          "mail_smtppassword": "***REMOVED SENSITIVE VALUE***",
          "test": {
              "key1": {
                  "key2": "10 20 30"
              }
          }
  ```
* The hash symbol in a string previously made the rest of the command be entirely ignored, now it works as expected:
  ```
  # occ theming:config color '#abcdef'
  Updated color to #abcdef
  # occ config:app:get theming color
  #abcdef
  # occ config:app:set theming color --value="#000000"
  Config value color for app theming set to #000000
  # occ theming:config color
  color is currently set to #000000
  ```

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
Fixes #179