### PR TITLE
Dockerfile: Raise opcache interned strings buffer to 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ RUN \
   echo 'apc.enable_cli=1' >> /etc/php7/conf.d/apcu.ini && \
   sed -i \
     -e 's/;opcache.enable.*=.*/opcache.enable=1/g' \
-    -e 's/;opcache.interned_strings_buffer.*=.*/opcache.interned_strings_buffer=8/g' \
+    -e 's/;opcache.interned_strings_buffer.*=.*/opcache.interned_strings_buffer=16/g' \
     -e 's/;opcache.max_accelerated_files.*=.*/opcache.max_accelerated_files=10000/g' \
     -e 's/;opcache.memory_consumption.*=.*/opcache.memory_consumption=128/g' \
     -e 's/;opcache.save_comments.*=.*/opcache.save_comments=1/g' \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -79,7 +79,7 @@ RUN \
   echo 'apc.enable_cli=1' >> /etc/php7/conf.d/apcu.ini && \
   sed -i \
     -e 's/;opcache.enable.*=.*/opcache.enable=1/g' \
-    -e 's/;opcache.interned_strings_buffer.*=.*/opcache.interned_strings_buffer=8/g' \
+    -e 's/;opcache.interned_strings_buffer.*=.*/opcache.interned_strings_buffer=16/g' \
     -e 's/;opcache.max_accelerated_files.*=.*/opcache.max_accelerated_files=10000/g' \
     -e 's/;opcache.memory_consumption.*=.*/opcache.memory_consumption=128/g' \
     -e 's/;opcache.save_comments.*=.*/opcache.save_comments=1/g' \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -79,7 +79,7 @@ RUN \
   echo 'apc.enable_cli=1' >> /etc/php7/conf.d/apcu.ini && \
   sed -i \
     -e 's/;opcache.enable.*=.*/opcache.enable=1/g' \
-    -e 's/;opcache.interned_strings_buffer.*=.*/opcache.interned_strings_buffer=8/g' \
+    -e 's/;opcache.interned_strings_buffer.*=.*/opcache.interned_strings_buffer=16/g' \
     -e 's/;opcache.max_accelerated_files.*=.*/opcache.max_accelerated_files=10000/g' \
     -e 's/;opcache.memory_consumption.*=.*/opcache.memory_consumption=128/g' \
     -e 's/;opcache.save_comments.*=.*/opcache.save_comments=1/g' \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -78,6 +78,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "11.09.21:", desc: "Increase OPCache interned strings buffered setting to 16." }
   - { date: "11.09.21:", desc: "Rebasing to alpine 3.14" }
   - { date: "21.03.21:", desc: "Publish `php8` tag for testing." }
   - { date: "25.02.21:", desc: "Nginx default site config updated for v21 (existing users should delete `/config/nginx/site-confs/default` and restart the container)." }


### PR DESCRIPTION
In line with https://github.com/nextcloud/docker/pull/1702/ and to avoid the error message:
> The OPcache interned strings buffer is nearly full. To assure that repeating strings can be effectively cached, it is recommended to apply opcache.interned_strings_buffer to your PHP configuration with a value higher than 8.

--- 

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-nextcloud/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications



## Description:
Raise OPCache interned strings buffer to 16 instead of 8.

## Benefits of this PR and context:
Removes the error message.

## How Has This Been Tested?
Tested on a live container to work and remove the error message.

## Source / References:
https://github.com/nextcloud/server/issues/31223

closes #235 