### PR TITLE
Fix LDAP module (legacy AJAX endpoints)

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -78,6 +78,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "14.04.21:", desc: "Nginx default site config updated for v23 (existing users should delete `/config/nginx/site-confs/default` and restart the container). Fix LDAP connection." }
   - { date: "11.09.21:", desc: "Rebasing to alpine 3.14" }
   - { date: "21.03.21:", desc: "Publish `php8` tag for testing." }
   - { date: "25.02.21:", desc: "Nginx default site config updated for v21 (existing users should delete `/config/nginx/site-confs/default` and restart the container)." }

--- a/root/defaults/default
+++ b/root/defaults/default
@@ -104,6 +104,9 @@ server {
     # then Nginx will encounter an infinite rewriting loop when it prepends `/index.php`
     # to the URI, resulting in a HTTP 500 error response.
     location ~ \.php(?:$|/) {
+        # Required for legacy support
+        rewrite ^/(?!index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy) /index.php$request_uri;
+
         fastcgi_split_path_info ^(.+?\.php)(/.*)$;
         set $path_info $fastcgi_path_info;
 

--- a/root/defaults/default
+++ b/root/defaults/default
@@ -27,6 +27,7 @@ server {
 
     # set max upload size
     client_max_body_size 512M;
+    client_body_timeout 300s;
     fastcgi_buffers 64 4K;
 
     # Enable gzip but do not remove ETag headers
@@ -35,7 +36,7 @@ server {
     gzip_comp_level 4;
     gzip_min_length 256;
     gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
-    gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
+    gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/wasm application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
 
     # HTTP response headers borrowed from Nextcloud `.htaccess`
     add_header Referrer-Policy                      "no-referrer"   always;
@@ -85,19 +86,23 @@ server {
     # `location ~ /(\.|autotest|...)` which would otherwise handle requests
     # for `/.well-known`.
     location ^~ /.well-known {
-        # The following 6 rules are borrowed from `.htaccess`
+        # The rules in this block are an adaptation of the rules
+        # in `.htaccess` that concern `/.well-known`.
 
-        location = /.well-known/carddav     { return 301 /remote.php/dav/; }
-        location = /.well-known/caldav      { return 301 /remote.php/dav/; }
-        # Anything else is dynamically handled by Nextcloud
-        location ^~ /.well-known            { return 301 /index.php$uri; }
+        location = /.well-known/carddav { return 301 /remote.php/dav/; }
+        location = /.well-known/caldav  { return 301 /remote.php/dav/; }
 
-        try_files $uri $uri/ =404;
+        location /.well-known/acme-challenge    { try_files $uri $uri/ =404; }
+        location /.well-known/pki-validation    { try_files $uri $uri/ =404; }
+
+        # Let Nextcloud's API for `/.well-known` URIs handle all other
+        # requests by passing them to the front-end controller.
+        return 301 /index.php$request_uri;
     }
 
     # Rules borrowed from `.htaccess` to hide certain paths from clients
     location ~ ^/(?:build|tests|config|lib|3rdparty|templates|data)(?:$|/)  { return 404; }
-    location ~ ^/(?:\.|autotest|occ|issue|indie|db_|console)              { return 404; }
+    location ~ ^/(?:\.|autotest|occ|issue|indie|db_|console)                { return 404; }
 
     # Ensure this block, which passes PHP files to the PHP process, is above the blocks
     # which handle static assets (as seen below). If this block is not declared first,
@@ -123,18 +128,29 @@ server {
 
         fastcgi_intercept_errors on;
         fastcgi_request_buffering off;
+
+        fastcgi_max_temp_file_size 0;
     }
 
-    location ~ \.(?:css|js|svg|gif)$ {
+    location ~ \.(?:css|js|svg|gif|png|jpg|ico|wasm|tflite|map)$ {
         try_files $uri /index.php$request_uri;
         expires 6M;         # Cache-Control policy borrowed from `.htaccess`
         access_log off;     # Optional: Don't log access to assets
+
+        location ~ \.wasm$ {
+            default_type application/wasm;
+        }
     }
 
     location ~ \.woff2?$ {
         try_files $uri /index.php$request_uri;
         expires 7d;         # Cache-Control policy borrowed from `.htaccess`
         access_log off;     # Optional: Don't log access to assets
+    }
+
+    # Rule borrowed from `.htaccess`
+    location /remote {
+        return 301 /remote.php$request_uri;
     }
 
     location / {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-nextcloud/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PRs though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Added a line that is missing from the NGINX configuration for Nextcloud 20.0 and up. It appears the Linuxserver container does not have this line, and Nextcloud apps that use legacy AJAX endpoints (such as the LDAP module) fail to work.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Resolves #236 "LDAP Integration Not Functional" and restores the ability for users to authenticate their Nextcloud instances against LDAP servers.

In short, this is related to a [PR in Nextcloud 19 that cleaned up the recommended NGINX configuration](https://github.com/nextcloud/documentation/pull/2197). Unfortunately, a side effect of this cleanup was the [breaking of the LDAP module](https://github.com/nextcloud/documentation/pull/2197#issuecomment-702530259), or modules that utilize legacy AJAX endpoints in general. It appears that when #188 was merged, the [necessary and recommended version-specific (Nextcloud 21) line to fix legacy endpoints](https://docs.nextcloud.com/server/21/admin_manual/installation/nginx.html) was not included. This PR is just to close that gap and restore the missing functionality.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Relevant line was added to NGINX config. Container was restarted. Confirmed LDAP module now works as expected and other Nextcloud functionality is unaffected.
![image](https://user-images.githubusercontent.com/34781835/163241320-52dcb858-5c4e-486f-8a15-e4839bc4c755.png)

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
See [my response to #236](https://github.com/linuxserver/docker-nextcloud/issues/236#issuecomment-1098352519) for more information.

## Additional info:
PR #225 appears to attempt to address this, however that PR puts the rewrite in a position that does not follow the [Nextcloud documentation](https://docs.nextcloud.com/server/latest/admin_manual/installation/nginx.html).
```php
    # Make a regex exception for `/.well-known` so that clients can still
    # access it despite the existence of the regex rule
    # `location ~ /(\.|autotest|...)` which would otherwise handle requests
    # for `/.well-known`.
    location ^~ /.well-known {
        # The following 6 rules are borrowed from `.htaccess`

        # Required for legacy support
        rewrite ^/(?!index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy) /index.php$request_uri;
```

The change should actually be made here to ensure there are no issues going forward:
```php
    # Ensure this block, which passes PHP files to the PHP process, is above the blocks
    # which handle static assets (as seen below). If this block is not declared first,
    # then Nginx will encounter an infinite rewriting loop when it prepends `/index.php`
    # to the URI, resulting in a HTTP 500 error response.
    location ~ \.php(?:$|/) {
        # Required for legacy support
        rewrite ^/(?!index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy) /index.php$request_uri;

        fastcgi_split_path_info ^(.+?\.php)(/.*)$;
        set $path_info $fastcgi_path_info;
```
