### PR TITLE
Add `postgresql-client` package to allow nextcloud backup application to work correctly.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN \
     gnu-libiconv \
     imagemagick \
     libxml2 \
+    postgresql-client \
     php7-apcu \
     php7-bcmath \
     php7-bz2 \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -31,6 +31,7 @@ RUN \
     gnu-libiconv \
     imagemagick \
     libxml2 \
+    postgresql-client \
     php7-apcu \
     php7-bcmath \
     php7-bz2 \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -31,6 +31,7 @@ RUN \
     gnu-libiconv \
     imagemagick \
     libxml2 \
+    postgresql-client \
     php7-apcu \
     php7-bcmath \
     php7-bz2 \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -78,6 +78,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "12.09.22:", desc: "Add `postgresql-client` to allow offical backup application to work correctly." }
   - { date: "21.05.22:", desc: "Update version check endpoint." }
   - { date: "28.04.22:", desc: "Increase OPCache interned strings buffered setting to 16." }
   - { date: "14.04.22:", desc: "Nginx default site config updated for v23 (existing users should delete `/config/nginx/site-confs/default` and restart the container). Fix LDAP connection." }


### PR DESCRIPTION
Add `postgresql-client` package to allow nextcloud backup application to work correctly.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X ] I have read the [contributing](https://github.com/linuxserver/docker-nextcloud/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
When using the official Nextcloud backup application the process will fail with the error:

```
In SqlDumpPgSQL.php line 80:
                                                                                          
  The dump process failed with exitcode 127 : Command not found : sh: pg_dump: not found
```

This merge request adds the `postgresql-client` packages which provides the `pg_dump` command.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

Allows the backup application https://github.com/nextcloud/backup to run.

Fixes #228 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* Build containers using instructions located in the documentation.
* Checked pg_dump application is installed.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->

* https://github.com/linuxserver/docker-nextcloud/issues/228
