### PR TITLE
Add update check to init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ RUN \
       | jq -r '.[] | select(.prerelease != true) | .tag_name' \
       | sed 's|^v||g' | sort -rV | head -1); \
   fi && \
+  echo "${NEXTCLOUD_RELEASE}" >/app/NEXTCLOUD_RELEASE_INCLUDED && \
   echo "**** download nextcloud ****" && \
   curl -o /app/nextcloud.tar.bz2 -L \
     https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_RELEASE}.tar.bz2 && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -75,6 +75,7 @@ RUN \
       | jq -r '.[] | select(.prerelease != true) | .tag_name' \
       | sed 's|^v||g' | sort -rV | head -1); \
   fi && \
+  echo "${NEXTCLOUD_RELEASE}" >/app/NEXTCLOUD_RELEASE_INCLUDED && \
   echo "**** download nextcloud ****" && \
   curl -o /app/nextcloud.tar.bz2 -L \
     https://download.nextcloud.com/server/releases/nextcloud-${NEXTCLOUD_RELEASE}.tar.bz2 && \

--- a/root/etc/s6-overlay/s6-rc.d/init-nextcloud-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-nextcloud-config/run
@@ -25,6 +25,52 @@ lsiown abc:abc \
     /config/www/nextcloud/config/config.php \
     /data
 
+# update check
+if [[ -f /config/www/nextcloud/version.php ]]; then
+    # Version Functions
+    # https://stackoverflow.com/questions/4023830/how-to-compare-two-strings-in-dot-separated-version-format-in-bash#comment92693604_4024263
+    vergte() { printf '%s\n%s' "${2}" "${1}" | sort -C -V; }
+    vergt() { ! vergte "${2}" "${1}"; }
+    verlte() { printf '%s\n%s' "${1}" "${2}" | sort -C -V; }
+    verlt() { ! verlte "${2}" "${1}"; }
+
+    NEXTCLOUD_RELEASE_AVAILABLE=$(curl -sX GET https://api.github.com/repos/nextcloud/server/releases |
+        jq -r '.[] | select(.prerelease != true) | .tag_name' |
+        sed 's|^v||g' | sort -rV | head -1)
+    NEXTCLOUD_RELEASE_INCLUDED=$(</app/NEXTCLOUD_RELEASE_INCLUDED)
+    OC_VERSION=$(php -r "include('/config/www/nextcloud/version.php'); print \$OC_VersionString;")
+
+    if vergt "${NEXTCLOUD_RELEASE_AVAILABLE}" "${OC_VERSION}"; then
+        cat <<-EOF
+
+
+
+################################################################
+#                                                              #
+#            An upgrade is available for Nextcloud.            #
+#                                                              #
+################################################################
+
+Installed Version: ${OC_VERSION}
+Available Version: ${NEXTCLOUD_RELEASE_AVAILABLE}
+Container Version: ${NEXTCLOUD_RELEASE_INCLUDED} (may require a container image update)
+
+################################################################
+#                                                              #
+#        To update Nextcloud, run the following command        #
+#                                                              #
+#            docker exec -it nextcloud updater.phar            #
+#                                                              #
+################################################################
+
+
+
+EOF
+        sleep 5s
+    fi
+fi
+
+# remove code server
 if (occ app:list --no-interaction | grep -q richdocumentscode) 2>/dev/null; then
     echo "Removing CODE Server"
     APP=$(occ app:list --no-interaction | grep richdocumentscode | awk -F ' ' '{print $2}' | tr -d ':')


### PR DESCRIPTION
- write the packaged version number to `/app/NEXTCLOUD_RELEASE_INCLUDED`
- check if the Nextcloud version.php exists
- check if the version of Nextcloud installed is less than the newest version available
- display a log message if an update is available

![image](https://github.com/linuxserver/docker-nextcloud/assets/725456/65b520b4-868d-466f-8704-c01e7f8e2a0f)
The versions in my screenshot are all the same because I don't have an update to do on my personal instance. I would not see this message, but I forced it to show so I could get the screenshot.