### PR TITLE
Set php defaults to match nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,10 +70,10 @@ RUN \
   } >> "/etc/php82/conf.d/00_opcache.ini" && \
   { \
     echo 'memory_limit=512M'; \
-    echo 'upload_max_filesize=16G'; \
-    echo 'post_max_size=16G'; \
-    echo 'max_input_time=3600'; \
-    echo 'max_execution_time=3600'; \
+    echo 'upload_max_filesize=512M'; \
+    echo 'post_max_size=512M'; \
+    echo 'max_input_time=300'; \
+    echo 'max_execution_time=300'; \
     echo 'output_buffering=0'; \
     echo 'always_populate_raw_post_data=-1'; \
   } >> "/etc/php82/conf.d/nextcloud.ini" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -70,10 +70,10 @@ RUN \
   } >> "/etc/php82/conf.d/00_opcache.ini" && \
   { \
     echo 'memory_limit=512M'; \
-    echo 'upload_max_filesize=16G'; \
-    echo 'post_max_size=16G'; \
-    echo 'max_input_time=3600'; \
-    echo 'max_execution_time=3600'; \
+    echo 'upload_max_filesize=512M'; \
+    echo 'post_max_size=512M'; \
+    echo 'max_input_time=300'; \
+    echo 'max_execution_time=300'; \
     echo 'output_buffering=0'; \
     echo 'always_populate_raw_post_data=-1'; \
   } >> "/etc/php82/conf.d/nextcloud.ini" && \


### PR DESCRIPTION
Sets the default values for php back to the NC defaults, which are already present in the nginx conf