### PR TITLE
Remove updatenotification

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-nextcloud-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-nextcloud-config/run
@@ -142,17 +142,17 @@ fi
 
 # remove problematic apps
 for APP in richdocumentscode updatenotification; do
-    if occ app:list | grep -q " - ${APP}:" 2>/dev/null; then
+    if (occ app:list | grep -q " - ${APP}:") 2>/dev/null; then
         echo "Removing ${APP}"
     fi
-    APP_PATH=$(occ app:getpath "${APP}")
+    APP_PATH=$(occ app:getpath "${APP}" 2>/dev/null)
     if [ -z "${APP_PATH}" ] || [ ! -d "${APP_PATH}" ]; then
         APP_PATH="/app/www/public/apps/${APP}"
     fi
     if [ -d "${APP_PATH}" ]; then
         occ app:disable "${APP}" >/dev/null 2>&1
     fi
-    APP_STATUS="$(occ config:app:get "${APP}" enabled)"
+    APP_STATUS="$(occ config:app:get "${APP}" enabled 2>/dev/null)"
     if [ "${APP_STATUS}" != "no" ] && [ -n "${APP_STATUS}" ]; then
         occ config:app:set "${APP}" enabled --value="no" >/dev/null 2>&1
     fi

--- a/root/etc/s6-overlay/s6-rc.d/init-nextcloud-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-nextcloud-config/run
@@ -140,11 +140,25 @@ else
     echo "https://docs.nextcloud.com/server/latest/admin_manual/configuration_files/files_locking_transactional.html"
 fi
 
-if (occ app:list --no-interaction | grep -q richdocumentscode) 2>/dev/null; then
-    echo "Removing CODE Server"
-    APP=$(occ app:list --no-interaction | grep richdocumentscode | awk -F ' ' '{print $2}' | tr -d ':')
-    occ app:remove --no-interaction "${APP}" 2>/dev/null
-fi
+# remove problematic apps
+for APP in richdocumentscode updatenotification; do
+    if occ app:list | grep -q " - ${APP}:" 2>/dev/null; then
+        echo "Removing ${APP}"
+    fi
+    APP_PATH=$(occ app:getpath "${APP}")
+    if [ -z "${APP_PATH}" ] || [ ! -d "${APP_PATH}" ]; then
+        APP_PATH="/app/www/public/apps/${APP}"
+    fi
+    if [ -d "${APP_PATH}" ]; then
+        occ app:disable "${APP}" >/dev/null 2>&1
+    fi
+    APP_STATUS="$(occ config:app:get "${APP}" enabled)"
+    if [ "${APP_STATUS}" != "no" ] && [ -n "${APP_STATUS}" ]; then
+        occ config:app:set "${APP}" enabled --value="no" >/dev/null 2>&1
+    fi
+    occ app:remove "${APP}" >/dev/null 2>&1
+    rm -rf "${APP_PATH}"
+done
 
 # set data directory
 if [ ! -s /config/www/nextcloud/config/config.php ]; then


### PR DESCRIPTION
All this app does is place a notification in the admin status page telling the user to click a button to run the web updater. We don't want this. Users should instead update the container image.

I tested the logic on my own instance. No issues. It runs completely silent if the apps don't exist.

Ref:
https://github.com/nextcloud/all-in-one/blob/1771a72c0e5a37d43356c4d3e6c657dc5d4a0990/Containers/nextcloud/entrypoint.sh#L186-L192
https://github.com/nextcloud/all-in-one/blob/1771a72c0e5a37d43356c4d3e6c657dc5d4a0990/Containers/nextcloud/entrypoint.sh#L286-L287

Also added to https://github.com/linuxserver/docker-nextcloud/pull/352