### PR TITLE
Disable web upgrades using occ during init develop

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -79,6 +79,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "28.10.23:", desc: "Disable web upgrades using occ during init." }
   - { date: "31.08.23:", desc: "Re-add updatenotification app. This allows users to be notified for app updates, but also notifies for NextCloud updates. Updating NextCloud via the web UI is not supported when using this image." }
   - { date: "14.08.23:", desc: "Add develop branch." }
   - { date: "25.06.23:", desc: "Move Nextcloud installation inside container. Remove CLI updater. [See changes announcement](https://info.linuxserver.io/issues/2023-06-25-nextcloud/)." }

--- a/root/etc/s6-overlay/s6-rc.d/init-nextcloud-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-nextcloud-config/run
@@ -125,13 +125,16 @@ if occ config:system:get installed >/dev/null 2>&1; then
         occ config:system:set memcache.local --value='\\OC\\Memcache\\APCu'
     fi
     if ! occ config:system:get filelocking.enabled >/dev/null 2>&1; then
-        occ config:system:set filelocking.enabled --value=true
+        occ config:system:set filelocking.enabled --value=true --type=boolean
     fi
     if ! occ config:system:get memcache.locking >/dev/null 2>&1; then
         occ config:system:set memcache.locking --value='\\OC\\Memcache\\APCu'
     fi
     if ! occ config:system:get datadirectory >/dev/null 2>&1; then
         occ config:system:set datadirectory --value='/data'
+    fi
+    if ! occ config:system:get upgrade.disable-web >/dev/null 2>&1; then
+        occ config:system:set upgrade.disable-web --value=true --type=boolean
     fi
 else
     echo "After completing the web-based installer, restart the Nextcloud container to apply default memory caching and transactional file locking configurations."


### PR DESCRIPTION
Ref:
https://github.com/nextcloud/server/issues/41172#issuecomment-1783892700
https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/config_sample_php_parameters.html#upgrade-disable-web
Note that boolean type setting is documented here https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/occ_command.html#setting-a-single-configuration-value and was added to `filelocking.enabled` as well

PR for master https://github.com/linuxserver/docker-nextcloud/pull/375