### PR TITLE
Increase PHP memory limit to 640MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN \
     echo 'opcache.jit_buffer_size=128M'; \
   } >> "/etc/php82/conf.d/00_opcache.ini" && \
   { \
-    echo 'memory_limit=512M'; \
+    echo 'memory_limit=640M'; \
     echo 'upload_max_filesize=512M'; \
     echo 'post_max_size=512M'; \
     echo 'max_input_time=300'; \


### PR DESCRIPTION
 - [x] I have read the [contributing](https://github.com/linuxserver/docker-nextcloud/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

## Description:

The previews of "big" photos from standard cameras (like Samsung A53 phone - full resolution image) are not generated.

## Example

```
occ preview:generate 70410
PHP Fatal error:  Allowed memory size of 536870912 bytes exhausted
  (tried to allocate 28672 bytes) in
  /app/www/public/lib/private/legacy/OC_Image.php on line 533
```