### PR TITLE
install imagemagick-svg from community

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN \
     ffmpeg \
     gnu-libiconv \
     imagemagick \
+    imagemagick-svg \
     libxml2 \
     php83-apcu \
     php83-bcmath \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -18,6 +18,7 @@ RUN \
     ffmpeg \
     gnu-libiconv \
     imagemagick \
+    imagemagick-svg \
     libxml2 \
     php83-apcu \
     php83-bcmath \


### PR DESCRIPTION
Install the imagemagick-svg to quell a new warning:

The PHP module "imagick" in this instance has no SVG support. For better compatibility it is recommended to install it.