### PR TITLE
fix external trigger (when upstream marks a previous version as latest on GH)

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -26,7 +26,7 @@ jobs:
           echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
           echo "> External trigger running off of previous branch. To disable this trigger, add \`nextcloud_previous\` into the Github organizational variable \`SKIP_EXTERNAL_TRIGGER\`." >> $GITHUB_STEP_SUMMARY
           printf "\n## Retrieving external version\n\n" >> $GITHUB_STEP_SUMMARY
-          EXT_RELEASE=$(curl -u ${{ secrets.CR_USER }}:${{ secrets.CR_PAT }} -sX GET https://api.github.com/repos/nextcloud/server/releases | jq -r "first(.[] | select(.tag_name | contains($(( $(curl -u ${{ secrets.CR_USER }}:${{ secrets.CR_PAT }} -sX GET https://api.github.com/repos/nextcloud/server/releases/latest | jq -r '.tag_name' | sed 's|^v||g' | awk -F '.' '{print $1}') -1 ))|tostring ) and (contains( \"rc\" )|not)) | .tag_name)" | sed 's|^v||g')
+          EXT_RELEASE=$(curl -u ${{ secrets.CR_USER }}:${{ secrets.CR_PAT }} -sX GET https://api.github.com/repos/nextcloud/server/releases | jq -r "first(.[] | select(.tag_name | contains($(( $(curl -u ${{ secrets.CR_USER }}:${{ secrets.CR_PAT }} -sX GET https://api.github.com/repos/nextcloud/server/releases | jq -r '.[] | select(.prerelease != true) | .tag_name' | sed 's|^v||g' | awk -F '.' '{print $1}' | sort -rV | head -1) -1 ))|tostring ) and (contains( \"rc\" )|not)) | .tag_name)" | sed 's|^v||g')
           echo "Type is \`custom_version_command\`" >> $GITHUB_STEP_SUMMARY
           if grep -q "^nextcloud_previous_${EXT_RELEASE}" <<< "${SKIP_EXTERNAL_TRIGGER}"; then
             echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,7 +143,7 @@ pipeline {
       steps{
         script{
           env.EXT_RELEASE = sh(
-            script: ''' curl -sX GET https://api.github.com/repos/nextcloud/server/releases | jq -r "first(.[] | select(.tag_name | contains($(( $(curl -sX GET https://api.github.com/repos/nextcloud/server/releases/latest | jq -r '.tag_name' | sed 's|^v||g' | awk -F '.' '{print $1}') -1 ))|tostring ) and (contains( \\"rc\\" )|not)) | .tag_name)" | sed 's|^v||g' ''',
+            script: ''' curl -sX GET https://api.github.com/repos/nextcloud/server/releases | jq -r "first(.[] | select(.tag_name | contains($(( $(curl -sX GET https://api.github.com/repos/nextcloud/server/releases | jq -r '.[] | select(.prerelease != true) | .tag_name' | sed 's|^v||g' | awk -F '.' '{print $1}' | sort -rV | head -1) -1 ))|tostring ) and (contains( \\"rc\\" )|not)) | .tag_name)" | sed 's|^v||g' ''',
             returnStdout: true).trim()
             env.RELEASE_LINK = 'custom_command'
         }

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -3,7 +3,7 @@
 # jenkins variables
 project_name: docker-nextcloud
 external_type: na
-custom_version_command: "curl -sX GET https://api.github.com/repos/nextcloud/server/releases | jq -r \"first(.[] | select(.tag_name | contains($(( $(curl -sX GET https://api.github.com/repos/nextcloud/server/releases/latest | jq -r '.tag_name' | sed 's|^v||g' | awk -F '.' '{print $1}') -1 ))|tostring ) and (contains( \\\\\"rc\\\\\" )|not)) | .tag_name)\" | sed 's|^v||g'"
+custom_version_command: "curl -sX GET https://api.github.com/repos/nextcloud/server/releases | jq -r \"first(.[] | select(.tag_name | contains($(( $(curl -sX GET https://api.github.com/repos/nextcloud/server/releases | jq -r '.[] | select(.prerelease != true) | .tag_name' | sed 's|^v||g' | awk -F '.' '{print $1}' | sort -rV | head -1) -1 ))|tostring ) and (contains( \\\\\"rc\\\\\" )|not)) | .tag_name)\" | sed 's|^v||g'"
 release_type: prerelease
 release_tag: previous
 ls_branch: previous


### PR DESCRIPTION
Current trigger relies on the latest and highest upstream version marked as latest on Github releases. That is not always the case as upstream publishes releases manually.

This PR retrieves all stable releases and sorts to figure out the highest major number and then calculates the previous version.