### PR TITLE
Adjust fastcgi timeout settings in default.conf.sample

### DIFF
--- a/root/defaults/nginx/site-confs/default.conf.sample
+++ b/root/defaults/nginx/site-confs/default.conf.sample
@@ -132,6 +132,12 @@ server {
         fastcgi_request_buffering off;
 
         fastcgi_max_temp_file_size 0;
+
+        # This ensures the processing of multipart uploads and prevents 504 errors during these resource-intensive operations.
+        fastcgi_connect_timeout 60s;
+        fastcgi_send_timeout 3600;
+        fastcgi_read_timeout 3600;
+        send_timeout 3600;
     }
 
     # Serve static files


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-nextcloud/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

Added some more generous timeouts to the default 60 seconds of nginx mo make possible to process large multipart uploads

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

In heavy uploads (usually multi GB) and using chunked uploads, the assembling process could take even minutes to end, resulting in a timeout on nginx (504 Gateway Timeout Error) while waiting for a response of php-fpm, this solves the issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested and working without issues since the date of publish of this PR to this date (8 months 2 days)



## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->

3600 seconds is the default timeout in the official all-in-one next cloud installer
